### PR TITLE
Fix privileged desktop launcher to use absolute binary path

### DIFF
--- a/mport-manager.desktop
+++ b/mport-manager.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=mport Package Manager
 Comment=MidnightBSD Package Manager
-Exec=gksudo mport-manager
+Exec=gksudo /usr/local/bin/mport-manager
 Icon=mport-manager
 Terminal=false
 Type=Application


### PR DESCRIPTION
### Motivation
- The desktop entry invoked `gksudo mport-manager`, which performs PATH-based command resolution in a privileged elevation path and can allow local PATH-based privilege escalation. 
- The package is installed to a fixed trusted location (`/usr/local/bin/mport-manager`), so the launcher should invoke that absolute path.

### Description
- Replace `Exec=gksudo mport-manager` with `Exec=gksudo /usr/local/bin/mport-manager` in `mport-manager.desktop` to avoid environment-dependent command lookup. 
- This is a minimal change that preserves existing behavior while removing the security risk.

### Testing
- Verified the desktop file before and after the change with `sed -n '1,80p' mport-manager.desktop` which showed the updated `Exec=` line. 
- Confirmed the file contents and commit with `nl -ba mport-manager.desktop | sed -n '1,20p'` and `git status --short`, and the change was successfully committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06aecc9f5c83229b5561875a3d8eae)

## Summary by Sourcery

Bug Fixes:
- Prevent potential PATH-based privilege escalation by changing the desktop entry to call /usr/local/bin/mport-manager explicitly instead of relying on PATH lookup.