### PR TITLE
Remove untrusted relative icon fallback for dialog icons

### DIFF
--- a/mport-manager.c
+++ b/mport-manager.c
@@ -124,14 +124,10 @@ static void create_installed_tree(void);
 static GtkWidget *
 create_app_icon_image(int pixel_size)
 {
-	const char *const icon_paths[] = {ICONFILE, "icon.png", NULL};
-
-	for (size_t i = 0; icon_paths[i] != NULL; i++) {
-		if (g_file_test(icon_paths[i], G_FILE_TEST_EXISTS)) {
-			GtkWidget *image = gtk_image_new_from_file(icon_paths[i]);
-			gtk_image_set_pixel_size(GTK_IMAGE(image), pixel_size);
-			return image;
-		}
+	if (g_file_test(ICONFILE, G_FILE_TEST_EXISTS)) {
+		GtkWidget *image = gtk_image_new_from_file(ICONFILE);
+		gtk_image_set_pixel_size(GTK_IMAGE(image), pixel_size);
+		return image;
 	}
 
 	GtkWidget *image = gtk_image_new_from_icon_name("dialog-information-symbolic");


### PR DESCRIPTION
### Motivation
- Prevent the privileged GUI from opening a CWD-controlled `icon.png` when the installed icon is absent by removing the unsafe relative-path fallback introduced in `create_app_icon_image()`.

### Description
- Update `create_app_icon_image()` so it only loads the trusted `ICONFILE` (`/usr/local/share/mport/icon.png`) when present and otherwise falls back to the GTK theme icon (`dialog-information-symbolic`), removing the `"icon.png"` fallback.

### Testing
- Ran repository checks and applied the patch (`git diff`, `nl -ba` on `mport-manager.c`, and committed the change); a full build/test run was not possible because GTK development packages were unavailable (compile failed with `gtk/gtk.h` not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073cb9dcb88322b5e9586912c9d405)

## Summary by Sourcery

Restrict dialog icon loading to a trusted installed icon file and otherwise fall back to the standard GTK theme icon.

Bug Fixes:
- Eliminate use of a current-working-directory-controlled icon file as a fallback for dialog icons to avoid loading untrusted images.

Enhancements:
- Simplify the app icon selection logic to check only the installed icon file before falling back to the theme-provided symbolic icon.