### PR TITLE
Fix install selection desync on package label allocation failure

### DIFF
--- a/mport-manager.c
+++ b/mport-manager.c
@@ -1020,10 +1020,14 @@ install(mportInstance *mport, const char *packageName)
 		while (*i2 != NULL)
 		{
 			char *package_info;
-			if (asprintf(&package_info, "%s-%s", (*i2)->pkgname, (*i2)->version) != -1) {
-				gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(combo_box), package_info);
-				free(package_info);
+			if (asprintf(&package_info, "%s-%s", (*i2)->pkgname, (*i2)->version) == -1)
+			{
+				gtk_window_destroy(GTK_WINDOW(dialog));
+				mport_index_entry_free_vec(indexEntryHead);
+				return MPORT_ERR_WARN;
 			}
+			gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(combo_box), package_info);
+			free(package_info);
 			item++;
 			i2++;
 		}


### PR DESCRIPTION
### Motivation
- Prevent a logic/integrity bug where `asprintf` failure during multi-version dialog population could skip visible combo-box rows and cause the selected UI index to map to the wrong `indexEntry`, potentially installing a different package/version than shown.

### Description
- In the multi-entry selection loop in `install()`, treat `asprintf` failure as a hard error by destroying the dialog, freeing `indexEntryHead`, and returning `MPORT_ERR_WARN`, and only append combo-box items after successful label formatting to preserve a 1:1 mapping between UI rows and backing entries.

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073d777ff08322bd21111a87ad68c2)

## Summary by Sourcery

Bug Fixes:
- Treat package label formatting failure during multi-version install selection as a hard error to avoid desynchronizing the selected UI entry from the backing index entry.