### PR TITLE
Fix recursive dependency install error handling

### DIFF
--- a/mport-manager.c
+++ b/mport-manager.c
@@ -1117,11 +1117,14 @@ install_depends(mportInstance *mport, const char *packageName, const char *versi
                 while (*depends != NULL) {
 					g_print("Installing dependency: %s version: %s\n", (*depends)->d_pkgname, (*depends)->d_version);
 
-                        install_depends(mport, (*depends)->d_pkgname, (*depends)->d_version, MPORT_AUTOMATIC);
+                        if (install_depends(mport, (*depends)->d_pkgname, (*depends)->d_version, MPORT_AUTOMATIC) != MPORT_OK) {
+					mport_index_depends_free_vec(dependsHead);
+                                return mport_err_code();
+                        }
                         depends++;
                 }
 				g_print("Installing main package...\n");
-                if (mport_install(mport, packageName, version, NULL, MPORT_EXPLICIT) != MPORT_OK) {
+                if (mport_install(mport, packageName, version, NULL, automatic) != MPORT_OK) {
 					g_warning("Main package installation failed: %s", mport_err_string());
 					mport_index_depends_free_vec(dependsHead);
                         msgbox(GTK_WINDOW(window), mport_err_string());


### PR DESCRIPTION
### Motivation
- The recursive dependency installer `install_depends()` previously ignored failures from recursive calls and advanced the `depends` pointer before freeing it, which could lead to freeing an interior pointer or using an uninitialized pointer when `mport_index_depends_list()` fails. 
- The change aims to harden error handling to avoid inconsistent state and memory-safety crashes during package installation while preserving existing install semantics.

### Description
- Check the return value of recursive `install_depends()` calls and propagate failures instead of ignoring them by returning `mport_err_code()` on error. 
- Ensure the original dependency vector (`dependsHead`) is freed before returning on recursive dependency install failure to avoid freeing an advanced/interior pointer. 
- Preserve the install mode by passing the function's `automatic` argument through to `mport_install()` instead of hardcoding `MPORT_EXPLICIT`.

### Testing
- Ran `git diff -- mport-manager.c` to verify the intended changes are present and `git status --short` to confirm the working tree state. 
- Changes were committed successfully, but a full build and runtime tests were not executed in this environment (GTK/mport runtime not validated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073d76dd4c8322963477f9c21ff24e)

## Summary by Sourcery

Improve error handling and installation semantics in recursive dependency installation.

Bug Fixes:
- Propagate errors from recursive dependency installations instead of ignoring failures to avoid inconsistent state and potential crashes.
- Free the original dependency vector before returning on failure to prevent freeing an interior or advanced pointer.

Enhancements:
- Preserve the caller-specified install mode by passing the existing automatic flag through to package installation instead of hardcoding it.