### PR TITLE
Free indexEntries on empty lookup to fix memory leak in populate_update_packages

### DIFF
--- a/mport-manager.c
+++ b/mport-manager.c
@@ -1754,6 +1754,8 @@ populate_update_packages(GtkTreeStore *store)
         if (indexEntries == NULL || *indexEntries == NULL)
 		{
             g_debug("No index entries for package: %s", (*pack)->name);
+			if (indexEntries != NULL)
+				mport_index_entry_free_vec(indexEntries);
             continue;
         }
 


### PR DESCRIPTION
### Motivation
- Fix a memory leak where `mport_index_lookup_pkgname()` could return an allocated (possibly empty) `indexEntries` vector that was not freed on the empty-result path in `populate_update_packages()`, allowing a malicious or corrupted index to cause unbounded memory retention while populating the Updates list.

### Description
- Add a call to `mport_index_entry_free_vec(indexEntries)` before `continue` when `indexEntries` is non-NULL but empty in `populate_update_packages()` in `mport-manager.c`, preserving the existing free on the non-empty path and keeping behavior otherwise unchanged.

### Testing
- No automated tests or full builds were executed in this environment due to missing GTK development headers and dependencies, and the change was validated by inspecting the diff and confirming the inserted free call.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073d7865a883228c0b0514f35aed40)

## Summary by Sourcery

Bug Fixes:
- Ensure indexEntries vectors returned from package index lookups are freed even when empty to prevent unbounded memory retention during update population.