### PR TITLE
Guard populate_remote_index() against NULL package metadata

### DIFF
--- a/mport-manager.c
+++ b/mport-manager.c
@@ -1602,10 +1602,14 @@ populate_remote_index(GtkTreeStore *store)
 	/* Build a hash set of "name\tversion" for installed packages so the
 	 * outer loop can do O(1) lookups instead of an O(m) linear scan. */
 	GHashTable *installed_set = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
-	while (*packs != NULL) {
-		gchar *key = g_strdup_printf("%s\t%s", (*packs)->name, (*packs)->version);
-		g_hash_table_insert(installed_set, key, GINT_TO_POINTER(1));
-		packs++;
+	if (packs != NULL) {
+		while (*packs != NULL) {
+			if ((*packs)->name != NULL && (*packs)->version != NULL) {
+				gchar *key = g_strdup_printf("%s\t%s", (*packs)->name, (*packs)->version);
+				g_hash_table_insert(installed_set, key, GINT_TO_POINTER(1));
+			}
+			packs++;
+		}
 	}
 
 	/* Detach model from view during bulk insert to suppress per-row redraws. */
@@ -1616,19 +1620,25 @@ populate_remote_index(GtkTreeStore *store)
 
 	while (*indexEntries != NULL) {
 		GtkTreeIter iter;
-		gchar *key = g_strdup_printf("%s\t%s", (*indexEntries)->pkgname, (*indexEntries)->version);
-		gboolean installed = g_hash_table_lookup(installed_set, key) != NULL;
-		g_free(key);
+		const char *pkgname = (*indexEntries)->pkgname;
+		const char *version = (*indexEntries)->version;
+		gboolean installed = FALSE;
+
+		if (pkgname != NULL && version != NULL) {
+			gchar *key = g_strdup_printf("%s\t%s", pkgname, version);
+			installed = g_hash_table_lookup(installed_set, key) != NULL;
+			g_free(key);
+		}
 
 #ifdef DEBUG
 		g_print("Working on %s\n", (*indexEntries)->pkgname);
 #endif
 
-		if (!installed) {
+		if (!installed && pkgname != NULL && version != NULL) {
 			gtk_tree_store_append(store, &iter, NULL);
 			gtk_tree_store_set(store, &iter,
-			                   TITLE_COLUMN, (*indexEntries)->pkgname,
-			                   VERSION_COLUMN, (*indexEntries)->version,
+			                   TITLE_COLUMN, pkgname,
+			                   VERSION_COLUMN, version,
 			                   -1);
 		}
 


### PR DESCRIPTION
### Motivation
- Prevent NULL-dereference crashes and denial-of-service in `populate_remote_index()` when local installed-package metadata or remote index entries are malformed or contain `NULL` `name`/`version`/`pkgname` fields.
- Preserve existing installed-detection behavior for well-formed metadata while avoiding crashes during GUI startup or index refresh.

### Description
- Add a `packs != NULL` guard before iterating the installed-package vector returned by `mport_pkgmeta_list()` to avoid walking a NULL pointer.
- Skip installed-package entries whose `name` or `version` are `NULL` when building the installed lookup `GHashTable` so no lookup keys are created from malformed metadata.
- Read `pkgname` and `version` into local `const char *` variables and only create/lookup the combined key when both are non-NULL, and only append rows to the tree when `pkgname`/`version` are present.
- Keep existing cleanup and model detach/reattach logic so behavior for valid repositories is unchanged.

### Testing
- `make` was run to build the project and it failed in this environment because GTK4 development files are unavailable (`pkg-config` could not find `gtk4.pc` and `gtk/gtk.h`), so a full build could not be completed here (failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073d7730588322ae3ba33eb278c9f2)

## Summary by Sourcery

Guard remote index population against NULL package metadata to avoid crashes while preserving existing behavior for valid data.

Bug Fixes:
- Avoid NULL-pointer dereferences when iterating installed packages by checking the package list and skipping entries with missing name or version.
- Prevent crashes when processing remote index entries by ignoring entries with NULL pkgname or version before key lookup and UI insertion.