### PR TITLE
Fix NULL dereference in update version comparison

### DIFF
--- a/mport-manager.c
+++ b/mport-manager.c
@@ -1764,6 +1764,12 @@ populate_update_packages(GtkTreeStore *store)
                 continue;
             }
 
+			if ((*pack)->version == NULL)
+			{
+				g_warning("Null installed version for package: %s", (*pack)->name);
+				continue;
+			}
+
 			int version_cmp = mport_version_cmp((*pack)->version, (*entry)->version);
 			int os_cmp = ((*pack)->os_release != NULL) ? mport_version_cmp((*pack)->os_release, os_release) : 0;
 


### PR DESCRIPTION
### Motivation
- Prevent a crash/DoS during startup when `populate_update_packages()` can call `mport_version_cmp()` with a NULL installed package `version` due to malformed package metadata.

### Description
- Add an explicit `NULL` check for `(*pack)->version` in `populate_update_packages()` (in `mport-manager.c`), log a warning and `continue` to skip the malformed record before calling `mport_version_cmp()`.

### Testing
- Ran repository inspections and edits (`rg`, `sed`), reviewed the resulting `git diff`, and committed the change; these automated checks completed successfully and the diff shows the added guard protecting the comparison.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073d78769883229dd5dcd5ead833a5)

## Summary by Sourcery

Bug Fixes:
- Prevent a potential NULL dereference in populate_update_packages() by skipping packages with a missing installed version before performing version comparison.