### PR TITLE
Use libmport-provided yes/no labels and default in GTK confirm dialog

### DIFF
--- a/mport-manager.c
+++ b/mport-manager.c
@@ -113,7 +113,7 @@ static void install_button_clicked(GtkButton *button, GtkWidget *parent);
 static void installed_delete_button_clicked(GtkButton *button, GtkWidget *parent);
 static void msgbox(GtkWindow *parent, const char * msg);
 static void msgbox_modal(GtkWindow *parent, const char *title, const char *button_label, const char *msg);
-static bool msgbox_bool(GtkWindow *parent, const char *msg);
+static bool msgbox_bool(GtkWindow *parent, const char *msg, const char *yes, const char *no, int def);
 static void cut_clicked (GtkButton *, GtkEditable *);
 static void copy_clicked (GtkButton *, GtkEditable *);
 static void paste_clicked (GtkButton *, GtkEditable *);
@@ -383,7 +383,7 @@ mport_gtk_confirm_cb(const char *msg, const char *yes, const char *no, int def)
 {
 	bool response;
 
-	response = msgbox_bool(GTK_WINDOW(window), msg);
+	response = msgbox_bool(GTK_WINDOW(window), msg, yes, no, def);
 	if (response)
 		return MPORT_OK;
 	else
@@ -1273,16 +1273,20 @@ run_dialog_sync(GtkDialog *dialog)
  * Create a modal dialog with Yes/No question
  */
 static bool
-msgbox_bool(GtkWindow *parent, const char *msg)
+msgbox_bool(GtkWindow *parent, const char *msg, const char *yes, const char *no, int def)
 {
 	GtkWidget *dialog, *label, *image, *hbox;
 
 	dialog = gtk_dialog_new_with_buttons("Question", parent,
-	                                     GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,                     
-										 "_Yes", GTK_RESPONSE_ACCEPT,
-										 "_No", GTK_RESPONSE_REJECT,
+	                                     GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+	                                     yes != NULL ? yes : "_Yes", GTK_RESPONSE_ACCEPT,
+	                                     no != NULL ? no : "_No", GTK_RESPONSE_REJECT,
 										 NULL);
 	set_window_app_icon(GTK_WINDOW(dialog));
+	if (def == 0)
+		gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
+	else if (def == 1)
+		gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_REJECT);
 
 	label = gtk_label_new(msg);
 	image = create_app_icon_image(48);


### PR DESCRIPTION
### Motivation
- The libmport confirmation callback was wired to a GTK dialog that ignored the `yes`, `no`, and `def` parameters and therefore could present hardcoded button labels and default choice, risking misleading privileged confirmations.
- The existing `msgbox_bool()` helper only used `msg` and hardcoded `"_Yes"`/`"_No"` labels, and did not respect the default selection requested by libmport.
- The intent is to minimally remediate the UI/security issue by making the GTK dialog honor libmport-provided labels and default behavior while preserving existing dialog flow.

### Description
- Updated the prototype of `msgbox_bool()` to `static bool msgbox_bool(GtkWindow *parent, const char *msg, const char *yes, const char *no, int def);` and its implementation accordingly. 
- Forwarded libmport `yes`, `no`, and `def` arguments from `mport_gtk_confirm_cb()` into the `msgbox_bool()` call via `response = msgbox_bool(GTK_WINDOW(window), msg, yes, no, def);`.
- Made the dialog use provided `yes`/`no` labels when non-NULL and fall back to `"_Yes"`/`"_No"` otherwise.
- Added handling to set the dialog default response according to `def` by calling `gtk_dialog_set_default_response()` for accept/reject.

### Testing
- Searched and inspected occurrences with `rg -n` and `sed` to confirm the callback and helper locations, which completed successfully. 
- Applied the code changes and verified the patch with `git diff`, and committed the change with `git commit`, both of which succeeded. 
- Created the PR metadata using the `make_pr` helper, which produced the PR title/body successfully. 
- A prior attempted build of the GUI failed due to missing GTK dev packages (`Package 'gtk+-3.0' ... not found`), so a full build/test run could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073d78514c8322889477f078ec7446)

## Summary by Sourcery

Honor libmport-provided confirmation labels and default choice in the GTK confirmation dialog.

Bug Fixes:
- Fix GTK confirmation dialog ignoring libmport-provided yes/no labels and default selection.

Enhancements:
- Extend msgbox_bool helper and its call site to accept custom yes/no labels and default choice, falling back to existing labels when not provided.