### PR TITLE
Fix header bar edit buttons targeting wrong widget

### DIFF
--- a/mport-manager.c
+++ b/mport-manager.c
@@ -829,15 +829,15 @@ create_header_bar(GtkWidget *window, GtkWidget *search)
 	gtk_widget_add_css_class(edit_box, "linked");
 
 	GtkWidget *cut_btn = gtk_button_new_with_label("Cut");
-	g_signal_connect_swapped(cut_btn, "clicked", G_CALLBACK(cut_clicked), G_OBJECT(search));
+	g_signal_connect(cut_btn, "clicked", G_CALLBACK(cut_clicked), G_OBJECT(search));
 	gtk_box_append(GTK_BOX(edit_box), cut_btn);
 
 	GtkWidget *copy_btn = gtk_button_new_with_label("Copy");
-	g_signal_connect_swapped(copy_btn, "clicked", G_CALLBACK(copy_clicked), G_OBJECT(search));
+	g_signal_connect(copy_btn, "clicked", G_CALLBACK(copy_clicked), G_OBJECT(search));
 	gtk_box_append(GTK_BOX(edit_box), copy_btn);
 
 	GtkWidget *paste_btn = gtk_button_new_with_label("Paste");
-	g_signal_connect_swapped(paste_btn, "clicked", G_CALLBACK(paste_clicked), G_OBJECT(search));
+	g_signal_connect(paste_btn, "clicked", G_CALLBACK(paste_clicked), G_OBJECT(search));
 	gtk_box_append(GTK_BOX(edit_box), paste_btn);
 
 	gtk_header_bar_pack_end(GTK_HEADER_BAR(header_bar), edit_box);


### PR DESCRIPTION
### Motivation
- The Cut/Copy/Paste header-bar buttons were connected with `g_signal_connect_swapped`, which swapped the callback arguments so clipboard actions were invoked on the clicked button instead of the search `GtkEditable`, causing a UI regression.

### Description
- In `create_header_bar` replaced `g_signal_connect_swapped(...)` with `g_signal_connect(...)` for the Cut/Copy/Paste buttons so the existing handlers (`GtkButton *, GtkEditable *`) receive the expected argument order and operate on the search entry.

### Testing
- Confirmed the change by searching for the signal connections and handlers with `rg`, inspected the diff, and ran a build dry-run with `make -n` to verify the compile command generation; all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073d772d4083228b6159e72119f107)

## Summary by Sourcery

Bug Fixes:
- Fix Cut/Copy/Paste header bar buttons so their actions operate on the search GtkEditable rather than the clicked button widget.