### PR TITLE
Create hicolor icon directory before installing icon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ install:
 	install mport-manager ${DESTDIR}${PREFIX}/bin/mport-manager
 	mkdir -p ${DESTDIR}${DATADIR}
 	install -m 444 icon.png ${DESTDIR}${DATADIR}/icon.png
+	mkdir -p ${DESTDIR}${PREFIX}/share/icons/hicolor/48x48/apps
 	install -m 444 icon.png ${DESTDIR}${PREFIX}/share/icons/hicolor/48x48/apps/mport-manager.png
 	install -m 444 mport-manager.desktop ${DESTDIR}${PREFIX}/share/applications/
 


### PR DESCRIPTION
### Motivation
- Fix installation failure on fresh `DESTDIR`s where `${PREFIX}/share/icons/hicolor/48x48/apps` was not created before installing `mport-manager.png` and caused `make install` to exit with error.

### Description
- Add `mkdir -p ${DESTDIR}${PREFIX}/share/icons/hicolor/48x48/apps` to the `install` target in `Makefile` immediately before the `mport-manager.png` install, preserving all other install behavior.

### Testing
- Ran `nl -ba Makefile | sed -n '16,30p'` and `make -n install` to confirm the directory creation step appears before the icon install, and both commands showed the expected successful output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073e6cd8388322a9ef06b472229ce5)

## Summary by Sourcery

Bug Fixes:
- Prevent installation failures on fresh DESTDIR setups by creating the hicolor 48x48 apps icon directory prior to installing the mport-manager icon.