### PR TITLE
Fix NULL-pointer dereference in lock()/unlock()

### DIFF
--- a/mport-manager.c
+++ b/mport-manager.c
@@ -1923,13 +1923,17 @@ lock(mportInstance *mport, const char *packageName)
 {
 	mportPackageMeta **packs = lookup_for_lock(mport, packageName);
 
-	if (packs != NULL) {
-		mport_lock_lock(mport, (*packs));
+	if (packs == NULL)
+		return (MPORT_ERR_FATAL);
+
+	if (*packs == NULL) {
 		mport_pkgmeta_vec_free(packs);
-		return (MPORT_OK);
+		return (MPORT_ERR_FATAL);
 	}
 
-	return (MPORT_ERR_FATAL);
+	mport_lock_lock(mport, (*packs));
+	mport_pkgmeta_vec_free(packs);
+	return (MPORT_OK);
 }
 
 static int
@@ -1937,11 +1941,15 @@ unlock(mportInstance *mport, const char *packageName)
 {
 	mportPackageMeta **packs = lookup_for_lock(mport, packageName);
 
-	if (packs != NULL) {
-		mport_lock_unlock(mport, (*packs));
+	if (packs == NULL)
+		return (MPORT_ERR_FATAL);
+
+	if (*packs == NULL) {
 		mport_pkgmeta_vec_free(packs);
-		return (MPORT_OK);
+		return (MPORT_ERR_FATAL);
 	}
 
-	return (MPORT_ERR_FATAL);
+	mport_lock_unlock(mport, (*packs));
+	mport_pkgmeta_vec_free(packs);
+	return (MPORT_OK);
 }


### PR DESCRIPTION
## Problem

`lookup_for_lock()` returns the vector from `mport_pkgmeta_search_master()` whenever the search **succeeds**, even when there are zero matches. In that case the call returns a non-NULL vector whose first element is `NULL` — the same condition `delete()` already guards against with `packs == NULL || *packs == NULL` (mport-manager.c:1176).

`lock()` and `unlock()` only checked `packs != NULL` before dereferencing `*packs` and passing it into `mport_lock_lock()` / `mport_lock_unlock()`. Locking or unlocking a package name that resolves to an empty result set therefore dereferences `*packs == NULL` and crashes.

## Fix

Guard `*packs == NULL` in both functions and free the (empty) vector before returning the error, matching `delete()`'s existing handling.

```c
if (packs == NULL)
    return (MPORT_ERR_FATAL);

if (*packs == NULL) {
    mport_pkgmeta_vec_free(packs);
    return (MPORT_ERR_FATAL);
}
```

This also fixes a small leak of the empty vector on the no-match path.

## Testing

Not built locally: GTK+3 and libmport are MidnightBSD platform dependencies not present on the dev host. The change is a localized NULL guard mirroring the established `delete()` pattern; CI (`make all`) exercises the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent NULL-pointer dereferences when locking and unlocking packages that resolve to no search results.

Bug Fixes:
- Guard against NULL first elements in the package metadata vector in lock() and unlock() to avoid crashes when no packages match.
- Ensure the empty package metadata vector is freed on the no-match path to eliminate a small memory leak.