### PR TITLE
Fix out-of-bounds read on package-select combo index

### DIFF
--- a/mport-manager.c
+++ b/mport-manager.c
@@ -1058,6 +1058,14 @@ install(mportInstance *mport, const char *packageName)
 
 		gtk_window_destroy(GTK_WINDOW(dialog));
 
+		// gtk_combo_box_get_active() returns -1 when nothing is
+		// selected; guard against an out-of-bounds pointer offset.
+		if (choice < 0 || choice >= item)
+		{
+			mport_index_entry_free_vec(indexEntryHead);
+			return MPORT_ERR_WARN;
+		}
+
 		// Set indexEntry to the chosen package
 		indexEntry += choice;
 	}


### PR DESCRIPTION
## Problem

When an index lookup returns multiple entries, `install()` presents a combo box and selects the chosen entry via `gtk_combo_box_get_active()`, then advances the entry pointer:

```c
choice = gtk_combo_box_get_active(GTK_COMBO_BOX(combo_box));
...
indexEntry += choice;
...
g_print("... %s ...", (*indexEntry)->pkgname, ...);  // deref
```

`gtk_combo_box_get_active()` returns `-1` when no item is active. A negative `choice` offsets `indexEntry` before the start of the vector, and the subsequent `(*indexEntry)->pkgname` dereference reads out of bounds. The combo is seeded with `set_active(0)`, so this is not normally reachable, but there is no guard if the active index is ever `-1` (or otherwise out of range).

## Fix

Bound `choice` to `[0, item)` (the entry count already computed when populating the combo) before applying the offset. On an invalid selection, free the entry vector and return `MPORT_ERR_WARN`, mirroring the existing cancel path.

```c
if (choice < 0 || choice >= item)
{
    mport_index_entry_free_vec(indexEntryHead);
    return MPORT_ERR_WARN;
}

indexEntry += choice;
```

## Testing

Not built locally: GTK+3 and libmport are MidnightBSD platform dependencies not present on the dev host. The change is a localized bounds check using in-scope variables and the established free/return pattern; CI (`make all`) exercises the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent an out-of-bounds read when gtk_combo_box_get_active() returns an invalid index for the package selection combo box.